### PR TITLE
fix: sort by location

### DIFF
--- a/clippings.js
+++ b/clippings.js
@@ -118,7 +118,21 @@ function getBook(collection, title, startFrom) {
 function getText(book, showLocation) {
   var text = '';
   var locationArray = [];
-  for (var i in book) {
+  const getSingleLocation = x => {
+    if (!x.location) return x
+    const index = x.location.indexOf('-')
+    if (index > -1) {
+      return Object.assign({}, x, {
+        location: Number(x.location.substr(0, index)),
+      })
+    }
+    return Object.assign({}, x, {
+      location: Number(x.location),
+    })
+  }
+  book = _.map(book, getSingleLocation)
+  book = _.sortBy(book, 'location')
+  for (let i = 0; i < book.length; i++) {
     var b = book[i];
     if (b.location) {
       // Prevent from displaying doubled entries


### PR DESCRIPTION
If while reading, one goes back a few pages to mark some text, even though in the order of the book that comes before, in My Clippings.txt it will come last.

This fix makes sure the output is always sorted by Location.
